### PR TITLE
modify json data name receive from rpc server.

### DIFF
--- a/db/addressbuilder.py
+++ b/db/addressbuilder.py
@@ -72,7 +72,7 @@ def SaveAssetAddress(asset,address) :
 
     last_tx_time = GetTimeByBlockHeight(result['height'])
 
-    json_str = '{"asset":"%s", "address":"%s", "value":%s, "first_tx_time":%d, "last_tx_time":%d, "txid_list":[%s]}' %(asset,address,value,first_tx_time,last_tx_time,txid_str)
+    json_str = '{"asset":"%s", "address":"%s", "value":"%s", "first_tx_time":%d, "last_tx_time":%d, "txid_list":[%s]}' %(asset,address,value,first_tx_time,last_tx_time,txid_str)
     ads = json.loads(json_str)
     SaveAds(ads)
 
@@ -106,7 +106,7 @@ def SaveAddress(address) :
 
     last_tx_time = GetTimeByBlockHeight(result['height'])
 
-    json_str = '{"asset":"0", "address":"%s", "value":0, "first_tx_time":%d, "last_tx_time":%d, "txid_list":[%s]}' % (address, first_tx_time, last_tx_time, txid_str)
+    json_str = '{"asset":"0", "address":"%s", "value":"0", "first_tx_time":%d, "last_tx_time":%d, "txid_list":[%s]}' % (address, first_tx_time, last_tx_time, txid_str)
     ads = json.loads(json_str)
     SaveAds(ads)
 


### PR DESCRIPTION
fix bug:
1. trans value from decimal to string may lose precision, so save value in string.
2. when save address into table 'ads' with asset "0", should save base on old address, not with other assetid.

modify json data name receive from rpc server.

Signed-off-by: zhengq1 <ljqlyy@gmail.com>