### PR TITLE
Implemented APIs related to block retrieval (aside from proper error responses)

### DIFF
--- a/web/api.py
+++ b/web/api.py
@@ -72,15 +72,15 @@ def GetApi() :
 def GetJsonForBlock(block) :
 	data = {}
 	
-	data['height'] = block[0]['height']
-	data['time'] = block[0]['time']
-	data['hash'] = block[0]['hash']
-	data['previousblockhash'] = block[0]['previousblockhash']
-	data['merkleroot'] = block[0]['merkleroot']
-	data['miner'] = block[0]['nextminer']
-	data['size'] = block[0]['size']
-	data['version'] = block[0]['version']
-	data['txnum'] = block[0]['txnum']
+	data['height'] = block['height']
+	data['time'] = block['time']
+	data['hash'] = block['hash']
+	data['previousblockhash'] = block['previousblockhash']
+	data['merkleroot'] = block['merkleroot']
+	data['miner'] = block['nextminer']
+	data['size'] = block['size']
+	data['version'] = block['version']
+	data['txnum'] = block['txnum']
 	
 	json_str = json.dumps(data)
 	
@@ -120,7 +120,7 @@ def Api_V1_Block_Get_Current_Height() :
 def Api_V1_Block_Get_Current_Block() :
 	block = web.collection_blocks.find().sort("height",-1).limit(1)
 	
-	return GetJsonForBlock(block)
+	return GetJsonForBlock(block[0])
 
 def Api_V1_Block_Get_Block_By_Height(height) :
 	block = web.collection_blocks.find_one({"height":height})

--- a/web/api.py
+++ b/web/api.py
@@ -69,6 +69,23 @@ def GetApi() :
 
 	return html
 
+def GetJsonForBlock(block) :
+	data = {}
+	
+	data['height'] = block[0]['height']
+	data['time'] = block[0]['time']
+	data['hash'] = block[0]['hash']
+	data['previousblockhash'] = block[0]['previousblockhash']
+	data['merkleroot'] = block[0]['merkleroot']
+	data['miner'] = block[0]['nextminer']
+	data['size'] = block[0]['size']
+	data['version'] = block[0]['version']
+	data['txnum'] = block[0]['txnum']
+	
+	json_str = json.dumps(data)
+	
+	return json_str
+
 def Api_V1_Address_Get_Value(address) :
 	data = {}
 	data['address'] = address
@@ -101,13 +118,25 @@ def Api_V1_Block_Get_Current_Height() :
 	return json_str
 
 def Api_V1_Block_Get_Current_Block() :
-	return ''
+	block = web.collection_blocks.find().sort("height",-1).limit(1)
+	
+	return GetJsonForBlock(block)
 
-def Api_V1_Block_Get_Block() :
-	return ''
+def Api_V1_Block_Get_Block_By_Height(height) :
+	block = web.collection_blocks.find_one({"height":height})
+	
+	if block :
+		return GetJsonForBlock(block)
+	else
+		return 'Block not found'
 
-def Api_V1_Block_Get_Block(height,hash) :
-	return ''
+def Api_V1_Block_Get_Block_By_Hash(hash) :
+	block = web.collection_blocks.find_one({"hash":hash})
+	
+	if block:
+		return GetJsonForBlock(block)
+	else
+		return 'Block not found'
 
 def Api_V1_Tx_Get_Tx(txid) :
 	return ''

--- a/web/web.py
+++ b/web/web.py
@@ -462,11 +462,11 @@ def Api_V1_Block_Get_Current_Block() :
 
 @app.route('/api/v1/block/get_block/<int:height>')
 def Api_V1_Block_Get_Block_By_Height(height) :
-	return api.Api_V1_Block_Get_Block(height,None), {'content-type':'application/json'}
+	return api.Api_V1_Block_Get_Block_By_Height(height), {'content-type':'application/json'}
 
 @app.route('/api/v1/block/get_block/<regex("[a-zA-Z0-9]{64}"):hash>')
 def Api_V1_Block_Get_Block_By_Hash(hash) :
-	return api.Api_V1_Block_Get_Block(None,hash), {'content-type':'application/json'}
+	return api.Api_V1_Block_Get_Block_By_Hash(hash), {'content-type':'application/json'}
 
 @app.route('/api/v1/tx/get_tx/<regex("[a-zA-Z0-9]{64}"):txid>')
 def Api_V1_Tx_Get_Tx(txid) :


### PR DESCRIPTION
These changes implement getting the latest block, getting a block by height, and getting a block by hash.

These changes do **not** include error handling. I was not able to see any examples of existing HTTP error handling (e.g. returning 404) in the code so I'm not sure how you want to go about that. For now these calls simply return a 'Block not found' string that **definitely** should be a proper 404.

Finally, since I cannot read Chinese these changes have not been tested. I tried to guess what the readme says but I was not successful in getting my environment properly setup.